### PR TITLE
v1.1: Rust Crate Migration & crates.io Publishing

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,5 +1,31 @@
 # Project Milestones: Cupel
 
+## v1.1 Rust Crate Migration & crates.io Publishing (Shipped: 2026-03-15)
+
+**Delivered:** Migrated the Rust conformance implementation from wollax/assay into the cupel monorepo, published to crates.io with OIDC trusted publishing, added optional serde serialization, comprehensive docs.rs documentation, and CI feature coverage.
+
+**Phases completed:** 16-22 (15 plans total)
+
+**Key accomplishments:**
+
+- Rust crate scaffold with Edition 2024 compliance, MSRV 1.85, and standalone Cargo.toml for crates.io publishing
+- Full crate migration (32 source files, 28 conformance vectors) with tarball round-trip verification
+- Dual-language CI/CD with path-filtered GitHub Actions, cargo-deny supply chain checks, and OIDC-based release workflow
+- Published cupel 1.0.0 to crates.io; assay switched from path dependency to registry consumer (714 assay tests passing)
+- Optional serde feature flag with validation-on-deserialize for ContextBudget — constructor bypass impossible
+- docs.rs documentation suite: crate README, module docs, 33 compilable doctests, 3 standalone runnable examples
+
+**Stats:**
+
+- 11 Rust source files, 4,550 lines of Rust (source + tests + examples)
+- 94 tests (28 conformance + 33 serde + 33 doctests)
+- 7 phases, 15 plans, 22 requirements (all passed)
+- 2 days (2026-03-14 → 2026-03-15)
+
+**What's next:** TBD — next milestone via `/kata-add-milestone`
+
+---
+
 ## v1.0 Core Library (Shipped: 2026-03-14)
 
 **Delivered:** Complete .NET context management library for coding agents — pipeline engine, scoring, slicing, placement, explainability, fluent API, named policies, serialization, and 4 NuGet packages.

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -2,33 +2,30 @@
 
 ## What This Is
 
-Cupel is a .NET context management library for coding agents. Given a set of context items (messages, documents, tool outputs, memory) and a token budget, Cupel determines the optimal context window — maximizing information density while respecting the attention mechanics of any LLM. It serves both autonomous agent orchestration (Smelt spawning subagents) and interactive human-agent sessions.
+Cupel is a dual-language (.NET + Rust) context management library for coding agents. Given a set of context items (messages, documents, tool outputs, memory) and a token budget, Cupel determines the optimal context window — maximizing information density while respecting the attention mechanics of any LLM. It serves both autonomous agent orchestration (Smelt spawning subagents) and interactive human-agent sessions.
 
 Part of the Wollax agentic development stack: **Assay** (spec-driven development) → **Smelt** (orchestration) → **Cupel** (context management).
 
 ## Current State
 
-**Shipped:** v1.0 Core Library (2026-03-14)
+**Shipped:** v1.1 Rust Crate Migration & crates.io Publishing (2026-03-15)
+- .NET: 4,303 lines of C# across 56 source files, 641 tests, 4 NuGet packages
+- Rust: 4,550 lines across 11 source files, 94 tests (28 conformance + 33 serde + 33 doctests)
+- `cupel` crate published on crates.io (v1.1.0) with optional serde feature
+- Dual-language CI/CD with path-filtered GitHub Actions and OIDC trusted publishing
+- Language-agnostic specification with 28 required conformance test vectors
+- wollax/assay consuming cupel from crates.io registry
+
+<details>
+<summary>v1.0 Core Library (2026-03-14)</summary>
+
 - 4,303 lines of C# across 56 source files
 - 11,175 lines of test code across 49 test files (641 tests)
 - 4 NuGet packages: Core, DI Extensions, Tiktoken, Json
 - Language-agnostic specification with 28 conformance test vectors
 - Rust crate implementation (assay-cupel) passing all conformance vectors
 
-## Current Milestone: v1.1 Rust Crate Migration & crates.io Publishing
-
-**Goal:** Pull the `assay-cupel` Rust crate from `wollax/assay` into the cupel monorepo, publish as `cupel-rs` on crates.io, and have assay reference it as a crates.io consumer.
-
-**Target features:**
-
-- Rust crate at `crates/cupel/` in the cupel repo (standalone, no Cargo workspace)
-- Published to crates.io as `cupel-rs` v1.0.0 (spec-aligned versioning)
-- Conformance test vectors: single source of truth at `conformance/`, vendored copy in crate with CI drift guard
-- Dual-language CI/CD (Rust jobs added to GitHub Actions)
-- `rust-toolchain.toml` at repo root, `.editorconfig` extended for Rust
-- Assay updated to consume `cupel-rs` from crates.io (not path dependency)
-- `crates/assay-cupel/` deleted from assay repo after migration verified
-- Local dev workflow documented (`[patch.crates-io]` pattern)
+</details>
 
 ## Core Value
 
@@ -53,9 +50,18 @@ Given candidates and a budget, return the optimal context selection with full ex
 - JSON serialization with source-generated JsonSerializerContext — v1.0
 - 4 NuGet packages (Core, DI, Tiktoken, Json) published to nuget.org — v1.0
 
+- Rust crate migrated to cupel monorepo, published to crates.io — v1.1
+- Standalone Cargo.toml with MSRV 1.85, Edition 2024, all crates.io metadata — v1.1
+- Conformance vectors vendored with CI drift guard and tarball round-trip verification — v1.1
+- Dual-language CI (Rust + .NET) with path filtering and cargo-deny supply chain checks — v1.1
+- OIDC trusted publishing for crates.io releases — v1.1
+- wollax/assay switched from path dependency to crates.io registry consumer — v1.1
+- Optional serde feature with validation-on-deserialize for ContextBudget — v1.1
+- docs.rs documentation with crate README, module docs, 33 doctests, 3 standalone examples — v1.1
+
 ### Active
 
-(See REQUIREMENTS.md for v1.1 requirements)
+(No active milestone — run `/kata-add-milestone` to define next)
 
 ### Out of Scope
 
@@ -108,6 +114,12 @@ Given candidates and a budget, return the optimal context selection with full ex
 | No IContextSink | Cupel selects; consumers convert. Output adapters are scope creep. | Good |
 | ContextBudget as sealed class (not record) | Prevents with-expressions bypassing constructor validation | Good |
 | Language-agnostic specification | Enables multi-language implementations with conformance guarantee | Good |
+| Crate name `cupel` (not `cupel-rs`) | Shorter, cleaner — name was available on crates.io | Good |
+| Standalone Cargo.toml (no workspace) | Single-crate repo avoids workspace complexity; workspace-inherited fields not needed | Good |
+| OIDC trusted publishing with secret fallback | OIDC eliminates token management; fallback ensures first publish works before OIDC configured | Good |
+| Validation-on-deserialize for ContextBudget | Custom deserializer routes through constructor — prevents serde from bypassing invariants | Good |
+| Cargo.lock excluded from git | Library crate convention — consumers resolve their own dependency tree | Good |
+| Toolchain pinned to 1.85.0 (not 'stable') | MSRV alignment — CI and local builds use identical Rust version | Good |
 
 ---
-*Last updated: 2026-03-14 — v1.0 shipped, v1.1 active*
+*Last updated: 2026-03-15 — v1.1 shipped*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -34,177 +34,28 @@
 
 </details>
 
----
+<details>
+<summary>v1.1 Rust Crate Migration & crates.io Publishing (Phases 16-22) — SHIPPED 2026-03-15</summary>
 
-### v1.1 Rust Crate Migration & crates.io Publishing (Planned)
+**Goal:** Migrate Rust crate from wollax/assay into cupel monorepo, publish to crates.io, add serde feature flag, comprehensive documentation, and CI feature coverage.
 
-#### Phase 16: Pre-flight & Crate Scaffold
+- [x] Phase 16: Pre-flight & Crate Scaffold (2/2 plans)
+- [x] Phase 17: Crate Migration & Conformance Verification (2/2 plans)
+- [x] Phase 18: Dual-Language CI (2/2 plans)
+- [x] Phase 19: First Publish & Assay Switchover (2/2 plans)
+- [x] Phase 20: Serde Feature Flag (3/3 plans)
+- [x] Phase 21: docs.rs Documentation & Examples (3/3 plans)
+- [x] Phase 22: CI Feature Coverage (1/1 plan)
 
-**Goal:** Establish all pre-conditions before moving any Rust source files. Verify the `cupel-rs` crate name is available on crates.io, decide workspace layout and conformance vector strategy, write a complete standalone `Cargo.toml`, and configure Rust toolchain files. This phase is entirely pre-code gates — getting these wrong produces hard-to-reverse consequences.
+[Full archive](milestones/v1.1-ROADMAP.md)
 
-**Dependencies:** Phase 15 (Conformance Hardening — `quota-basic.toml` promoted to required tier, conformance vector vendoring must account for this)
-
-**Requirements:** MIGRATE-01, MIGRATE-02, MIGRATE-03, MIGRATE-04, MIGRATE-05
-
-**Success Criteria:**
-1. `cupel-rs` name availability verified on crates.io (or fallback name selected if squatted)
-2. `rust-toolchain.toml` at repo root pins Rust 2024 edition with MSRV 1.85, includes `rustfmt` and `clippy` components
-3. `.editorconfig` extended with Rust-specific rules; `.gitignore` includes `/crates/cupel/target/`
-4. Standalone `Cargo.toml` at `crates/cupel/` with all required fields (`name`, `version`, `edition`, `rust-version`, `license`, `repository`, `description`, `categories`, `keywords`, `include`) and chosen version strategy — no workspace-inherited fields
-5. `cargo check --manifest-path crates/cupel/Cargo.toml` passes on an empty `lib.rs` placeholder
-
-**Plans:** 2 plans
-
-Plans:
-- [x] 16-01-PLAN.md — Verify crate name availability, create .gitignore, rust-toolchain.toml, and extend .editorconfig
-- [x] 16-02-PLAN.md — Create standalone Cargo.toml and lib.rs placeholder, smoke-test with cargo check
-
----
-
-#### Phase 17: Crate Migration & Conformance Verification
-
-**Goal:** Move all Rust source files from `wollax/assay` into `crates/cupel/src/`, update conformance test vector paths, and verify the complete crate compiles, passes all conformance tests, and packages correctly for publishing.
-
-**Dependencies:** Phase 16 (crate scaffold exists)
-
-**Requirements:** MIGRATE-06, MIGRATE-07, CONFORM-01, CONFORM-02, CONFORM-03
-
-**Success Criteria:**
-1. All 26 `.rs` source files from `assay/crates/assay-cupel/src/` live at `cupel/crates/cupel/src/` and compile cleanly
-2. Conformance test runner resolves vectors from `conformance/required/` (including promoted `quota-basic.toml`) via `CARGO_MANIFEST_DIR`-relative path with CI diff guard preventing divergence
-3. `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` all pass with 28+ conformance vectors (28 original + promoted quota)
-4. `cargo package --list` confirms all `.toml` conformance vectors appear in the tarball
-5. Unpacked tarball verification: `tar xvf *.crate && cargo test` passes inside the unpacked directory
-
-**Plans:** 2 plans
-
-Plans:
-- [x] 17-01-PLAN.md — Copy 26 source files and 28 conformance vectors into crate, update Cargo.toml include, verify build/clippy/fmt
-- [x] 17-02-PLAN.md — Migrate 5 test files with import updates, set up pre-commit diff guard hook, verify tests/packaging/tarball round-trip
-
----
-
-#### Phase 18: Dual-Language CI
-
-**Goal:** Wire Rust CI into GitHub Actions alongside the existing .NET workflows. Separate workflow files with path filters ensure Rust changes trigger Rust CI and .NET changes trigger .NET CI. Release pipeline verified with dry-run before first publish.
-
-**Dependencies:** Phase 17 (crate compiles and tests pass locally)
-
-**Requirements:** CI-01, CI-02, CI-04, CI-05
-
-**Success Criteria:**
-1. `ci-rust.yml` triggers on PRs touching `crates/**`, `conformance/**`, `rust-toolchain.toml`, and self-referencing workflow path; runs `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, and `cargo-deny check`
-2. `release-rust.yml` with `workflow_dispatch` trigger, `dry-run` input, and `release` GitHub environment completes dry-run without error
-3. Existing `.NET` CI workflow has path filters so Rust-only changes do not trigger .NET builds
-4. `cargo-deny` configuration (`deny.toml`) exists and passes in CI
-5. GitHub branch protection accepts skipped Rust CI status check on .NET-only PRs (and vice versa)
-
-**Plans:** 2 plans
-
-Plans:
-- [x] 18-01-PLAN.md — Create Rust CI workflow, cargo-deny configuration, and add path filters to .NET CI
-- [x] 18-02-PLAN.md — Create Rust release workflow with dry-run support and environment gating
-
----
-
-#### Phase 19: First Publish & Assay Switchover
-
-**Goal:** Publish `cupel-rs` to crates.io, configure OIDC trusted publishing for future releases, and update `wollax/assay` to consume the crate from the registry instead of a path dependency. Delete the old `assay-cupel` directory from assay after verification.
-
-**Dependencies:** Phase 18 (CI passing, release workflow verified dry-run)
-
-**Requirements:** CI-03, SWITCH-01, SWITCH-02, SWITCH-03, SWITCH-04
-
-**Success Criteria:**
-1. `cupel-rs` is live on crates.io with correct metadata (readme rendered, categories visible, docs.rs build triggered)
-2. OIDC trusted publishing configured on crates.io settings page — subsequent publishes use `release-rust.yml` workflow without personal API tokens
-3. `wollax/assay` replaces `assay-cupel` path dependency with `cupel-rs = "VERSION"` from registry; imports renamed; all assay tests pass
-4. `assay/crates/assay-cupel/` directory deleted from assay repo
-5. `[patch.crates-io]` local development pattern documented in assay contributing guide
-
-**Plans:** 2 plans
-
-Plans:
-- [x] 19-01-PLAN.md — Fix release workflow for first publish (remove --locked, make_latest: true) and add OIDC support
-- [x] 19-02-PLAN.md — First publish to crates.io, configure OIDC trusted publishing, switch assay to registry dependency
-
----
-
-#### Phase 20: Serde Feature Flag
-
-**Goal:** Add optional `serde` feature flag gating `Serialize`/`Deserialize` derives on all public data types. This is the highest-value differentiator for Rust consumers — most LLM-application users need serialization. Requires careful `ContextBudget` custom deserializer to maintain constructor validation invariants.
-
-**Dependencies:** Phase 19 (crate published — this is a post-publish enhancement)
-
-**Requirements:** ENHANCE-01, ENHANCE-02, ENHANCE-03
-
-**Success Criteria:**
-1. `features = ["serde"]` in `Cargo.toml` gates `serde::Serialize` and `serde::Deserialize` derives on all public data types (`ContextItem`, `ContextBudget`, `ContextKind`, `ContextSource`, `ScoredItem`, etc.)
-2. `ContextBudget` uses a custom deserializer that validates inputs through the constructor — blind deserialization around validation is not possible
-3. `cargo test` passes with `--features serde` and without (feature is additive, not breaking)
-4. Crate re-published to crates.io as a minor version bump with the new feature
-
-**Plans:** 3 plans
-
-Plans:
-- [x] 20-01-PLAN.md — Add serde feature flag to Cargo.toml, implement serde for leaf types (ContextKind, ContextSource, OverflowStrategy)
-- [x] 20-02-PLAN.md — Implement serde for complex types (ContextItem, ScoredItem, ContextBudget, QuotaEntry) with validation-on-deserialize
-- [x] 20-03-PLAN.md — Comprehensive serde test suite (24 tests) and version bump to 1.1.0
-
----
-
-#### Phase 21: docs.rs Documentation & Examples
-
-**Goal:** Make `cupel-rs` discoverable and approachable on docs.rs with crate-level quickstart documentation, module-level doc comments, and runnable examples. This is the single largest factor in new-user conversion from the docs.rs landing page.
-
-**Dependencies:** Phase 20 (serde feature — docs should document the serde feature)
-
-**Requirements:** ENHANCE-04, ENHANCE-05
-
-**Success Criteria:**
-1. Crate-level documentation in `lib.rs` includes a quickstart example that compiles as a doctest
-2. Every public module has a `//!` module-level doc comment explaining its purpose; `[package.metadata.docs.rs]` configured with `all-features = true`
-3. `examples/basic_pipeline.rs` exists and runs with `cargo run --example basic_pipeline`
-4. `cargo doc --no-deps --all-features` builds with zero warnings
-
-**Plans:** 3 plans
-
-Plans:
-- [x] 21-01-PLAN.md — Write crate README with quickstart examples, wire lib.rs crate docs, configure docs.rs metadata
-- [x] 21-02-PLAN.md — Add module-level doc comments and compilable doctests to all public modules, structs, and traits
-- [x] 21-03-PLAN.md — Create three standalone runnable examples (basic_pipeline, serde_roundtrip, quota_slicing)
-
----
-
-#### Phase 22: CI Feature Coverage
-
-**Goal:** Ensure all Cargo features (specifically `serde`) are tested in CI and the release pipeline, closing the audit gap where 40+ serde tests are silently skipped on every CI run.
-
-**Dependencies:** Phase 20 (serde feature exists), Phase 18 (CI workflows exist)
-
-**Gap Closure:** Closes integration gap and flow gap from v1.1 milestone audit
-
-**Success Criteria:**
-1. `ci-rust.yml` runs `cargo test --all-features` in addition to default `cargo test` — serde tests execute on every PR
-2. `release-rust.yml` test job runs `cargo test --all-features` before publish — serde regressions block release
-3. Both default-features and all-features test runs pass in CI
-
-**Plans:** 1 plan
-
-Plans:
-- [x] 22-01-PLAN.md — Add --all-features test steps to ci-rust.yml and release-rust.yml
+</details>
 
 ---
 
 ## Progress Summary
 
-| Phase | Name | Requirements | Status |
-|-------|------|-------------|--------|
-| 1-15 | v1.0 Core Library | 44/44 requirements | SHIPPED |
-| 16 | Pre-flight & Crate Scaffold | MIGRATE-01-05 | ● complete |
-| 17 | Crate Migration & Conformance Verification | MIGRATE-06-07, CONFORM-01-03 | ● complete |
-| 18 | Dual-Language CI | CI-01-02, CI-04-05 | ● complete |
-| 19 | First Publish & Assay Switchover | CI-03, SWITCH-01-04 | ● complete |
-| 20 | Serde Feature Flag | ENHANCE-01-03 | ● complete |
-| 21 | docs.rs Documentation & Examples | ENHANCE-04-05 | ● complete |
-| 22 | CI Feature Coverage | Audit gap closure | ● complete |
+| Phase | Milestone | Status |
+|-------|-----------|--------|
+| 1-15 | v1.0 Core Library | SHIPPED (48 plans, 44 requirements) |
+| 16-22 | v1.1 Rust Crate Migration | SHIPPED (15 plans, 22 requirements) |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,20 +2,20 @@
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-03-14)
+See: .planning/PROJECT.md (updated 2026-03-15)
 
 **Core value:** Optimal context selection with full explainability
-**Current focus:** v1.1 Rust Crate Migration & crates.io Publishing
+**Current focus:** Planning next milestone
 
 ## Current Position
 
-Phase: 22 of 22 — CI Feature Coverage
-Milestone: v1.1 Rust Crate Migration & crates.io Publishing
-Plan: 1 of 1
-Status: Phase complete
-Last activity: 2026-03-15 — Completed 22-01-PLAN.md
+Phase: None active
+Milestone: v1.1 complete — next milestone TBD
+Plan: N/A
+Status: Ready for next milestone
+Last activity: 2026-03-15 — v1.1 milestone complete
 
-Progress: █████████████████████████████ 15/15 plans (v1.1)
+Progress: ████████████████████████████████ 22/22 phases shipped (v1.0 + v1.1)
 
 ## Phase Overview
 
@@ -24,36 +24,22 @@ NEXT_PHASE=none
 | Phase | Status |
 |-------|--------|
 | **v1.0 Core Library** | SHIPPED 2026-03-14 (15 phases, 48 plans) |
-| **v1.1 Rust Crate Migration & crates.io Publishing** | SHIPPED 2026-03-15 |
-| 16. Pre-flight & Crate Scaffold | ● complete (2/2 plans) |
-| 17. Crate Migration & Conformance Verification | ● complete (2/2 plans) |
-| 18. Dual-Language CI | ● complete (2/2 plans) |
-| 19. First Publish & Assay Switchover | ● complete (2/2 plans) |
-| 20. Serde Feature Flag | ● complete (3/3 plans) |
-| 21. docs.rs Documentation & Examples | ● complete (3/3 plans) |
-| 22. CI Feature Coverage | ● complete (1/1 plans) |
+| **v1.1 Rust Crate Migration & crates.io Publishing** | SHIPPED 2026-03-15 (7 phases, 15 plans) |
 
 ## Accumulated Context
 
 ### Decisions
-(Carried to PROJECT.md Key Decisions table — see v1.0 archive for full decision log)
-
-| ID | Decision | Phase |
-|----|----------|-------|
-| 16-01-D1 | Crate name `cupel` confirmed available — preferred name selected | 16-01 |
-| 16-01-D2 | Toolchain pinned to 1.85.0 (not 'stable') for MSRV alignment | 16-01 |
-| 16-01-D3 | Cargo.lock excluded from git (library crate convention) | 16-01 |
-| 17-01-D1 | Applied cargo fmt for edition 2024 formatting (source used edition 2021 style) | 17-01 |
-| 17-02-D1 | Added tests/**/*.rs to Cargo.toml include list for tarball round-trip verification | 17-02 |
-| 18-01-D1 | conformance/** excluded from ci-rust.yml paths — vendored copy covered by crates/** | 18-01 |
-| 19-01-D1 | OIDC auth with continue-on-error fallback to secret for first publish compatibility | 19-01 |
+(Carried to PROJECT.md Key Decisions table — see v1.0 and v1.1 archives for full decision logs)
 
 ### Roadmap Evolution
 - v1.0 shipped 2026-03-14 — 15 phases, 48 plans, 44/44 requirements, 641 tests
-- v1.1 shipped 2026-03-15 — 7 phases, 15 plans, 24 requirements
+- v1.1 shipped 2026-03-15 — 7 phases, 15 plans, 22/22 requirements, 94 Rust tests
 
 ### Blockers
 (None)
 
 ### Technical Debt
-(None — v1.0 tech debt is informational/by-design, documented in milestone audit archive)
+- assay Cargo.toml pins cupel = "1.0.0" — functional via semver but stale after 1.1.0
+- 74 open issues in .planning/issues/open/
+- deny.toml not documented in contributing guide
+- conformance/optional/ vectors not vendored (intentional but undocumented)

--- a/.planning/milestones/v1.1-MILESTONE-AUDIT.md
+++ b/.planning/milestones/v1.1-MILESTONE-AUDIT.md
@@ -1,0 +1,109 @@
+---
+milestone: v1.1
+audited: 2026-03-15
+status: passed
+scores:
+  requirements: 22/22
+  phases: 7/7
+  integration: 10/10
+  flows: 4/4
+gaps:
+  requirements: []
+  integration: []
+  flows: []
+tech_debt:
+  - phase: 19-first-publish--assay-switchover
+    items:
+      - "assay Cargo.toml pins cupel = '1.0.0' — functional via semver but stale after v1.1.0 publish"
+  - phase: 22-ci-feature-coverage
+    items:
+      - "CI uses --features serde instead of --all-features — functionally equivalent today but summary language says --all-features"
+  - phase: general
+    items:
+      - "74 open issues accumulated across v1.0 and v1.1 in .planning/issues/open/"
+      - "deny.toml not documented in any contributing guide"
+      - "conformance/optional/ vectors not vendored into crate (only required/ — intentional per spec design but undocumented)"
+---
+
+# v1.1 Milestone Audit: Rust Crate Migration & crates.io Publishing
+
+## Requirements Coverage
+
+All 22 requirements satisfied across 7 phases.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| MIGRATE-01 | 16 | PASS |
+| MIGRATE-02 | 16 | PASS |
+| MIGRATE-03 | 16 | PASS |
+| MIGRATE-04 | 16 | PASS |
+| MIGRATE-05 | 16 | PASS |
+| MIGRATE-06 | 17 | PASS |
+| MIGRATE-07 | 17 | PASS |
+| CONFORM-01 | 17 | PASS |
+| CONFORM-02 | 17 | PASS |
+| CONFORM-03 | 17 | PASS |
+| CI-01 | 18 | PASS |
+| CI-02 | 18 | PASS |
+| CI-04 | 18 | PASS |
+| CI-05 | 18 | PASS |
+| CI-03 | 19 | PASS |
+| SWITCH-01 | 19 | PASS |
+| SWITCH-02 | 19 | PASS |
+| SWITCH-03 | 19 | PASS |
+| SWITCH-04 | 19 | PASS |
+| ENHANCE-01 | 20 | PASS |
+| ENHANCE-02 | 20 | PASS |
+| ENHANCE-03 | 20 | PASS |
+| ENHANCE-04 | 21 | PASS |
+| ENHANCE-05 | 21 | PASS |
+
+## Phase Verification Summary
+
+| Phase | Name | Must-Haves | Status |
+|-------|------|------------|--------|
+| 16 | Pre-flight & Crate Scaffold | 10/10 | PASSED |
+| 17 | Crate Migration & Conformance Verification | 14/14 | PASSED |
+| 18 | Dual-Language CI | 11/11 | PASSED |
+| 19 | First Publish & Assay Switchover | 5/5 | PASSED |
+| 20 | Serde Feature Flag | 22/22 | PASSED |
+| 21 | docs.rs Documentation & Examples | 14/14 | PASSED |
+| 22 | CI Feature Coverage | 4/4 | PASSED |
+| **Total** | | **80/80** | **ALL PASSED** |
+
+## Integration Check
+
+### Connected (10 verified cross-phase connections)
+
+1. **Toolchain consistency** — rust-toolchain.toml (1.85.0), Cargo.toml (rust-version = "1.85"), ci-rust.yml (dtolnay/rust-toolchain@1.85.0), release-rust.yml (dtolnay/rust-toolchain@1.85.0) all aligned
+2. **Cargo.toml include → tarball** — src, tests, conformance vectors, examples, README, LICENSE all in include array and verified in cargo package --list
+3. **Conformance vector chain** — canonical conformance/required/ → vendored crates/cupel/conformance/required/ → pre-commit diff guard → CI cargo test → tarball packaging — end-to-end verified
+4. **CI path isolation** — ci-rust.yml triggers on crates/**, rust-toolchain.toml; ci.yml triggers on src/**, tests/**, *.slnx — zero overlap
+5. **Release workflow gates** — test job → publish job (needs: test) → environment: release → dry-run guard → OIDC auth → cargo publish → GitHub Release (rust-v tag)
+6. **Serde feature → CI** — Phase 22 added `--features serde` steps to both ci-rust.yml and release-rust.yml; 94 tests (28 conformance + 33 serde + 33 doctests) now execute on every PR and before publish
+7. **Documentation chain** — README.md → lib.rs include_str! → docs.rs renders → doctests compile (33 pass) → 3 examples compile and run
+8. **docs.rs → serde feature** — `[package.metadata.docs.rs]` sets `all-features = true` with `doc_auto_cfg` enabled; serde-gated items show automatic feature badges
+9. **Assay consumer** — cupel = "1.0.0" registry dep in assay workspace Cargo.toml (not path dep), CONTRIBUTING.md documents [patch.crates-io]
+10. **Pre-commit guard** — .githooks/pre-commit diffs canonical ↔ vendored conformance vectors, git config core.hooksPath = .githooks
+
+### E2E Flows
+
+| Flow | Status | Details |
+|------|--------|---------|
+| Developer workflow | PASS | Edit → cargo test → cargo test --features serde → commit (diff guard) → push → CI runs default + serde features |
+| Release workflow | PASS | Dispatch → test (fmt, clippy, test, test --features serde) → OIDC publish → GitHub Release |
+| Consumer workflow | PASS | assay declares cupel from registry → builds → conformance tests pass |
+| Documentation flow | PASS | README → crates.io + docs.rs → quickstart compiles → examples runnable |
+
+## Tech Debt
+
+### Phase 19: First Publish & Assay Switchover
+- assay Cargo.toml pins `cupel = "1.0.0"` — functional via semver resolution but stale after 1.1.0 publish
+
+### Phase 22: CI Feature Coverage
+- CI workflows use `--features serde` instead of `--all-features` — functionally equivalent (crate has exactly one optional feature) and arguably more precise, but differs from the phase summary's language
+
+### General
+- 74 open issues accumulated across v1.0 and v1.1 in `.planning/issues/open/`
+- deny.toml not documented in any contributing guide
+- `conformance/optional/` vectors not vendored into crate (only `required/` — intentional per spec design but undocumented)

--- a/.planning/milestones/v1.1-REQUIREMENTS.md
+++ b/.planning/milestones/v1.1-REQUIREMENTS.md
@@ -1,0 +1,88 @@
+# Requirements Archive: v1.1 Rust Crate Migration & crates.io Publishing
+
+**Archived:** 2026-03-15
+**Status:** ✅ SHIPPED
+
+This is the archived requirements specification for v1.1.
+For current requirements, see `.planning/REQUIREMENTS.md` (created for next milestone).
+
+---
+
+## Migration Requirements
+
+- [x] MIGRATE-01: cupel crate name available on crates.io (or fallback selected)
+- [x] MIGRATE-02: rust-toolchain.toml at repo root pins Rust 2024 edition with MSRV 1.85
+- [x] MIGRATE-03: .editorconfig extended with Rust-specific rules; .gitignore includes crate target
+- [x] MIGRATE-04: Standalone Cargo.toml with all required crates.io fields
+- [x] MIGRATE-05: cargo check passes on placeholder lib.rs
+- [x] MIGRATE-06: All 26 .rs source files compile cleanly at crates/cupel/src/
+- [x] MIGRATE-07: Conformance test runner resolves vectors from CARGO_MANIFEST_DIR-relative path
+
+## Conformance Requirements
+
+- [x] CONFORM-01: cargo fmt --check, cargo clippy -- -D warnings, and cargo test all pass with 28+ vectors
+- [x] CONFORM-02: cargo package --list confirms all .toml conformance vectors in tarball
+- [x] CONFORM-03: Unpacked tarball verification passes (tar xvf *.crate && cargo test)
+
+## CI Requirements
+
+- [x] CI-01: ci-rust.yml triggers on crates/**, conformance/**, rust-toolchain.toml changes
+- [x] CI-02: CI runs fmt, clippy, test, and cargo-deny checks
+- [x] CI-03: OIDC trusted publishing configured — no personal API tokens
+- [x] CI-04: release-rust.yml with dry-run support and environment gating
+- [x] CI-05: .NET CI workflow has path filters so Rust-only changes don't trigger .NET builds
+
+## Switchover Requirements
+
+- [x] SWITCH-01: cupel live on crates.io with correct metadata (readme, categories, docs.rs)
+- [x] SWITCH-02: wollax/assay replaces path dependency with cupel from registry
+- [x] SWITCH-03: assay/crates/assay-cupel/ directory deleted from assay repo
+- [x] SWITCH-04: [patch.crates-io] local development pattern documented
+
+## Enhancement Requirements
+
+- [x] ENHANCE-01: features = ["serde"] gates Serialize/Deserialize derives on all public types
+- [x] ENHANCE-02: ContextBudget custom deserializer validates through constructor
+- [x] ENHANCE-03: cargo test passes with and without --features serde (additive, not breaking)
+- [x] ENHANCE-04: Crate-level docs with quickstart example, module-level doc comments, docs.rs configured
+- [x] ENHANCE-05: examples/ directory with runnable examples, cargo doc builds with zero warnings
+
+## Traceability
+
+| Requirement | Phase | Status | Notes |
+|-------------|-------|--------|-------|
+| MIGRATE-01 | 16 | Complete | cupel name confirmed available |
+| MIGRATE-02 | 16 | Complete | Pinned to 1.85.0 |
+| MIGRATE-03 | 16 | Complete | |
+| MIGRATE-04 | 16 | Complete | Standalone, no workspace |
+| MIGRATE-05 | 16 | Complete | |
+| MIGRATE-06 | 17 | Complete | 26 files migrated |
+| MIGRATE-07 | 17 | Complete | CARGO_MANIFEST_DIR relative |
+| CONFORM-01 | 17 | Complete | 28 vectors passing |
+| CONFORM-02 | 17 | Complete | Verified in CI |
+| CONFORM-03 | 17 | Complete | Tarball round-trip verified |
+| CI-01 | 18 | Complete | Path-filtered triggers |
+| CI-02 | 18 | Complete | Full lint/test/deny pipeline |
+| CI-03 | 19 | Complete | OIDC with fallback |
+| CI-04 | 18 | Complete | Dry-run + environment gating |
+| CI-05 | 18 | Complete | .NET path filters added |
+| SWITCH-01 | 19 | Complete | Published as cupel 1.0.0 |
+| SWITCH-02 | 19 | Complete | assay consuming from registry |
+| SWITCH-03 | 19 | Complete | Old directory deleted |
+| SWITCH-04 | 19 | Complete | Documented in CONTRIBUTING.md |
+| ENHANCE-01 | 20 | Complete | 7 public types covered |
+| ENHANCE-02 | 20 | Complete | Custom deserializer |
+| ENHANCE-03 | 20 | Complete | Additive feature verified |
+| ENHANCE-04 | 21 | Complete | 33 doctests, docs.rs configured |
+| ENHANCE-05 | 21 | Complete | 3 examples, zero doc warnings |
+
+---
+
+## Milestone Summary
+
+**Shipped:** 22 of 22 requirements (plus 2 audit gap closures in Phase 22)
+**Adjusted:** None
+**Dropped:** None
+
+---
+*Archived: 2026-03-15 as part of v1.1 milestone completion*

--- a/.planning/milestones/v1.1-ROADMAP.md
+++ b/.planning/milestones/v1.1-ROADMAP.md
@@ -1,0 +1,115 @@
+# Milestone v1.1: Rust Crate Migration & crates.io Publishing
+
+**Status:** ✅ SHIPPED 2026-03-15
+**Goal:** Pull the assay-cupel Rust crate from wollax/assay into the cupel monorepo, publish as cupel on crates.io, add serde feature flag, comprehensive documentation, and CI feature coverage.
+**Phases:** 16-22
+**Total Plans:** 15
+
+## Overview
+
+Migrated the Rust conformance implementation from wollax/assay into the cupel monorepo as a standalone crate, published to crates.io, added optional serde serialization support, comprehensive docs.rs documentation with examples, and ensured CI tests all feature combinations.
+
+## Phases
+
+### Phase 16: Pre-flight & Crate Scaffold
+
+**Goal**: Establish all pre-conditions before moving any Rust source files.
+**Depends on**: Phase 15
+**Plans**: 2 plans
+
+Plans:
+- [x] 16-01: Verify crate name availability, create .gitignore, rust-toolchain.toml, and extend .editorconfig
+- [x] 16-02: Create standalone Cargo.toml and lib.rs placeholder, smoke-test with cargo check
+
+### Phase 17: Crate Migration & Conformance Verification
+
+**Goal**: Move all Rust source files from assay into crates/cupel/src/ and verify conformance.
+**Depends on**: Phase 16
+**Plans**: 2 plans
+
+Plans:
+- [x] 17-01: Copy 26 source files and 28 conformance vectors into crate, verify build/clippy/fmt
+- [x] 17-02: Migrate 5 test files with import updates, set up pre-commit diff guard hook, verify tests/packaging/tarball round-trip
+
+### Phase 18: Dual-Language CI
+
+**Goal**: Wire Rust CI into GitHub Actions alongside existing .NET workflows.
+**Depends on**: Phase 17
+**Plans**: 2 plans
+
+Plans:
+- [x] 18-01: Create Rust CI workflow, cargo-deny configuration, and add path filters to .NET CI
+- [x] 18-02: Create Rust release workflow with dry-run support and environment gating
+
+### Phase 19: First Publish & Assay Switchover
+
+**Goal**: Publish cupel to crates.io, configure OIDC trusted publishing, switch assay to registry dependency.
+**Depends on**: Phase 18
+**Plans**: 2 plans
+
+Plans:
+- [x] 19-01: Fix release workflow for first publish (remove --locked, make_latest: true) and add OIDC support
+- [x] 19-02: First publish to crates.io, configure OIDC trusted publishing, switch assay to registry dependency
+
+### Phase 20: Serde Feature Flag
+
+**Goal**: Add optional serde feature flag gating Serialize/Deserialize derives on all public data types.
+**Depends on**: Phase 19
+**Plans**: 3 plans
+
+Plans:
+- [x] 20-01: Add serde feature flag to Cargo.toml, implement serde for leaf types
+- [x] 20-02: Implement serde for complex types with validation-on-deserialize
+- [x] 20-03: Comprehensive serde test suite (24 tests) and version bump to 1.1.0
+
+### Phase 21: docs.rs Documentation & Examples
+
+**Goal**: Make cupel discoverable and approachable on docs.rs with crate-level quickstart, module docs, and runnable examples.
+**Depends on**: Phase 20
+**Plans**: 3 plans
+
+Plans:
+- [x] 21-01: Write crate README with quickstart examples, wire lib.rs crate docs, configure docs.rs metadata
+- [x] 21-02: Add module-level doc comments and compilable doctests to all public modules, structs, and traits
+- [x] 21-03: Create three standalone runnable examples (basic_pipeline, serde_roundtrip, quota_slicing)
+
+### Phase 22: CI Feature Coverage
+
+**Goal**: Ensure all Cargo features (specifically serde) are tested in CI and the release pipeline.
+**Depends on**: Phase 20, Phase 18
+**Plans**: 1 plan
+**Gap Closure**: Closes integration gap and flow gap from v1.1 milestone audit
+
+Plans:
+- [x] 22-01: Add --features serde test steps to ci-rust.yml and release-rust.yml
+
+---
+
+## Milestone Summary
+
+**Key Decisions:**
+- Crate name `cupel` confirmed available on crates.io (16-01)
+- Toolchain pinned to 1.85.0 for MSRV alignment (16-01)
+- Cargo.lock excluded from git (library crate convention) (16-01)
+- Applied cargo fmt for edition 2024 formatting (17-01)
+- Added tests/**/*.rs to Cargo.toml include list for tarball verification (17-02)
+- conformance/** excluded from ci-rust.yml paths — vendored copy covered by crates/** (18-01)
+- OIDC auth with continue-on-error fallback to secret for first publish compatibility (19-01)
+
+**Issues Resolved:**
+- Rust crate migrated from wollax/assay into cupel monorepo
+- Dual-language CI with path filtering prevents cross-language build triggers
+- OIDC trusted publishing eliminates personal API token dependency
+- Serde feature with validation-on-deserialize prevents constructor bypass
+- CI gap where 40+ serde tests were silently skipped — now always executed
+
+**Technical Debt:**
+- assay Cargo.toml pins cupel = "1.0.0" — functional via semver but stale after 1.1.0 publish
+- CI uses --features serde instead of --all-features — functionally equivalent today
+- 74 open issues accumulated in .planning/issues/open/
+- deny.toml not documented in contributing guide
+- conformance/optional/ vectors not vendored into crate (intentional per spec design but undocumented)
+
+---
+
+_For current project status, see .planning/ROADMAP.md_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-15
+
+### Added
+- Optional `serde` feature flag with Serialize/Deserialize derives on all public types (ContextItem, ScoredItem, ContextBudget, QuotaEntry, ContextKind, ContextSource, OverflowStrategy)
+- Custom ContextBudget deserializer that validates inputs through constructor — prevents bypass of invariants
+- Crate-level documentation with quickstart examples wired to docs.rs
+- Module-level doc comments with 33 compilable doctests across all public types
+- Three standalone runnable examples: basic_pipeline, serde_roundtrip, quota_slicing
+- docs.rs metadata with all-features = true and doc_auto_cfg for automatic feature badges
+
+### Fixed
+- CI now tests serde feature — closes gap where 40+ serde tests were silently skipped
+- Explicit `--features serde` in CI/release workflows for Clippy and Test steps
+
+### Changed
+- CI workflows (ci-rust.yml, release-rust.yml) updated to run both default and serde feature test passes
+
 ## [1.0.0] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 Context management library for coding agents. Given a set of context items and a token budget, Cupel determines the optimal context window — maximizing information density while respecting LLM attention mechanics.
 
+Available in **.NET** and **Rust**.
+
 ## Install
 
+**.NET:**
 ```bash
 dotnet add package Wollax.Cupel
 ```
@@ -13,6 +16,15 @@ Optional companions:
 dotnet add package Wollax.Cupel.Extensions.DependencyInjection
 dotnet add package Wollax.Cupel.Tiktoken
 dotnet add package Wollax.Cupel.Json
+```
+
+**Rust:**
+```toml
+[dependencies]
+cupel = "1.1"
+
+# Optional: serialization support
+cupel = { version = "1.1", features = ["serde"] }
 ```
 
 ## Quick Start
@@ -118,9 +130,19 @@ foreach (var excluded in report.Excluded)
 | `Wollax.Cupel.Tiktoken` | Token counting via Microsoft.ML.Tokenizers |
 | `Wollax.Cupel.Json` | JSON policy serialization |
 
+## Rust Crate
+
+The [`cupel`](https://crates.io/crates/cupel) crate implements the full conformance specification in Rust. See `crates/cupel/` for source and [docs.rs](https://docs.rs/cupel) for API documentation.
+
+Features:
+- Full conformance with all 28 required test vectors
+- Optional `serde` feature for Serialize/Deserialize on all public types
+- Validation-on-deserialize for `ContextBudget` (constructor invariants enforced)
+- 3 runnable examples: `basic_pipeline`, `serde_roundtrip`, `quota_slicing`
+
 ## Specification
 
-Cupel's algorithm is documented as a [language-agnostic specification](spec/) with 28 conformance test vectors. A [Rust implementation](https://github.com/wollax/assay/tree/main/crates/assay-cupel) validates the spec's language-independence.
+Cupel's algorithm is documented as a [language-agnostic specification](spec/) with 28 conformance test vectors. Both the .NET and Rust implementations pass all conformance vectors.
 
 ## License
 


### PR DESCRIPTION
## Summary

Completes milestone v1.1 — Rust crate migration, crates.io publishing, serde feature, documentation, and CI feature coverage.

**Key accomplishments:**
- Migrated Rust crate from wollax/assay into cupel monorepo, published to crates.io
- Added optional serde feature with validation-on-deserialize for ContextBudget
- Comprehensive docs.rs documentation: crate README, module docs, 33 doctests, 3 runnable examples
- Dual-language CI/CD with path filtering and OIDC trusted publishing
- CI feature coverage ensuring serde tests execute on every PR and before publish

## Release Files

- `CHANGELOG.md` — v1.1.0 entry added
- `README.md` — Rust crate install instructions, features, docs.rs links
- Crate already at v1.1.0 (bumped in phase 20-03)

## After Merge

Create GitHub Release with tag `v1.1`.

## Closes

Closes #26
Closes #27
Closes #28
Closes #29
Closes #30
Closes #31