### PR TITLE
feat(S02): Adopt TOML 1.1 syntax in conformance vectors & document requirement

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -51,6 +51,10 @@ Use any TOML library for your language. See the [Running the Suite](https://woll
 
 All score comparisons use epsilon tolerance (default `1e-9`). Never compare floating-point scores with exact equality.
 
+## TOML Version
+
+These vectors use [TOML 1.1](https://toml.io/) features, specifically optional seconds in offset date-times (e.g. `2024-01-01T00:00Z` instead of `2024-01-01T00:00:00Z`). Implementations consuming these vectors **must** use a TOML 1.1-capable parser.
+
 ## Version
 
 These vectors correspond to Cupel Specification v1.0.0.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -53,7 +53,7 @@ All score comparisons use epsilon tolerance (default `1e-9`). Never compare floa
 
 ## TOML Version
 
-These vectors use [TOML 1.1](https://toml.io/) features, specifically optional seconds in offset date-times (e.g. `2024-01-01T00:00Z` instead of `2024-01-01T00:00:00Z`). Implementations consuming these vectors **must** use a TOML 1.1-capable parser.
+These vectors use [TOML 1.1](https://toml.io/en/v1.1.0) features, specifically optional seconds in offset date-times (e.g. `2024-01-01T00:00Z` instead of `2024-01-01T00:00:00Z`). Implementations consuming these vectors **must** use a TOML 1.1-capable parser.
 
 ## Version
 

--- a/conformance/optional/pipeline/all-pinned.toml
+++ b/conformance/optional/pipeline/all-pinned.toml
@@ -36,14 +36,14 @@ pinned = true
 content = "old"
 tokens = 150
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 pinned = true
 
 [[items]]
 content = "new"
 tokens = 150
 kind = "Message"
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 pinned = true
 
 [[expected_output]]

--- a/conformance/optional/pipeline/deduplication.toml
+++ b/conformance/optional/pipeline/deduplication.toml
@@ -47,19 +47,19 @@ weight = 1.0
 content = "shared content"
 tokens = 100
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "shared content"
 tokens = 100
 kind = "Message"
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[items]]
 content = "unique"
 tokens = 100
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[expected_output]]
 content = "unique"

--- a/conformance/optional/pipeline/overflow-truncate.toml
+++ b/conformance/optional/pipeline/overflow-truncate.toml
@@ -86,19 +86,19 @@ pinned = true
 content = "msg-a"
 tokens = 100
 kind = "Message"
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[items]]
 content = "msg-b"
 tokens = 100
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[items]]
 content = "msg-c"
 tokens = 100
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[expected_output]]
 content = "msg-a"

--- a/conformance/optional/scoring/composite-nested.toml
+++ b/conformance/optional/scoring/composite-nested.toml
@@ -51,14 +51,14 @@ weight = 1.0
 [[items]]
 content = "a"
 tokens = 100
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 priority = 1
 futureRelevanceHint = 0.8
 
 [[items]]
 content = "b"
 tokens = 100
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 priority = 5
 futureRelevanceHint = 0.2
 

--- a/conformance/optional/scoring/recency-single-item.toml
+++ b/conformance/optional/scoring/recency-single-item.toml
@@ -8,7 +8,7 @@ scorer = "recency"
 [[items]]
 content = "only"
 tokens = 100
-timestamp = 2024-06-15T00:00:00Z
+timestamp = 2024-06-15T00:00Z
 
 [[expected]]
 content = "only"

--- a/conformance/required/pipeline/composite-greedy-chronological.toml
+++ b/conformance/required/pipeline/composite-greedy-chronological.toml
@@ -70,25 +70,25 @@ weight = 1.0
 content = "sys-old"
 tokens = 100
 kind = "SystemPrompt"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "msg-mid"
 tokens = 150
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[items]]
 content = "msg-new"
 tokens = 150
 kind = "Message"
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[items]]
 content = "doc-old"
 tokens = 200
 kind = "Document"
-timestamp = 2024-02-01T00:00:00Z
+timestamp = 2024-02-01T00:00Z
 
 [[expected_output]]
 content = "sys-old"

--- a/conformance/required/pipeline/diag-deduplicated.toml
+++ b/conformance/required/pipeline/diag-deduplicated.toml
@@ -57,13 +57,13 @@ weight = 1.0
 content = "dup-content"
 tokens = 50
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "dup-content"
 tokens = 50
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[expected_output]]
 content = "dup-content"

--- a/conformance/required/pipeline/diag-negative-tokens.toml
+++ b/conformance/required/pipeline/diag-negative-tokens.toml
@@ -47,13 +47,13 @@ weight = 1.0
 content = "neg-item"
 tokens = -5
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "normal-item"
 tokens = 100
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[expected_output]]
 content = "normal-item"

--- a/conformance/required/pipeline/diag-pinned-override.toml
+++ b/conformance/required/pipeline/diag-pinned-override.toml
@@ -77,7 +77,7 @@ pinned = true
 content = "regular-item"
 tokens = 80
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[expected_output]]
 content = "pinned-item"

--- a/conformance/required/pipeline/diag-scored-inclusion.toml
+++ b/conformance/required/pipeline/diag-scored-inclusion.toml
@@ -60,13 +60,13 @@ weight = 1.0
 content = "older-item"
 tokens = 50
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "newer-item"
 tokens = 50
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[expected_output]]
 content = "older-item"

--- a/conformance/required/pipeline/diagnostics-budget-exceeded.toml
+++ b/conformance/required/pipeline/diagnostics-budget-exceeded.toml
@@ -43,13 +43,13 @@ weight = 1.0
 content = "fits"
 tokens = 150
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[items]]
 content = "too-big"
 tokens = 400
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[expected_output]]
 content = "fits"

--- a/conformance/required/pipeline/greedy-chronological.toml
+++ b/conformance/required/pipeline/greedy-chronological.toml
@@ -46,25 +46,25 @@ weight = 1.0
 content = "jan"
 tokens = 200
 kind = "Message"
-timestamp = 2024-01-15T00:00:00Z
+timestamp = 2024-01-15T00:00Z
 
 [[items]]
 content = "mar"
 tokens = 200
 kind = "Message"
-timestamp = 2024-03-15T00:00:00Z
+timestamp = 2024-03-15T00:00Z
 
 [[items]]
 content = "aug"
 tokens = 150
 kind = "Message"
-timestamp = 2024-08-15T00:00:00Z
+timestamp = 2024-08-15T00:00Z
 
 [[items]]
 content = "dec"
 tokens = 150
 kind = "Message"
-timestamp = 2024-12-15T00:00:00Z
+timestamp = 2024-12-15T00:00Z
 
 [[expected_output]]
 content = "aug"

--- a/conformance/required/pipeline/greedy-ushaped.toml
+++ b/conformance/required/pipeline/greedy-ushaped.toml
@@ -46,25 +46,25 @@ weight = 1.0
 content = "oldest"
 tokens = 200
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "early"
 tokens = 150
 kind = "Message"
-timestamp = 2024-04-01T00:00:00Z
+timestamp = 2024-04-01T00:00Z
 
 [[items]]
 content = "late"
 tokens = 150
 kind = "Message"
-timestamp = 2024-09-01T00:00:00Z
+timestamp = 2024-09-01T00:00Z
 
 [[items]]
 content = "newest"
 tokens = 100
 kind = "Message"
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[expected_output]]
 content = "newest"

--- a/conformance/required/pipeline/knapsack-chronological.toml
+++ b/conformance/required/pipeline/knapsack-chronological.toml
@@ -59,21 +59,21 @@ content = "alpha"
 tokens = 200
 kind = "Message"
 priority = 2
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "beta"
 tokens = 150
 kind = "Message"
 priority = 5
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[items]]
 content = "gamma"
 tokens = 250
 kind = "Message"
 priority = 8
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[expected_output]]
 content = "gamma"

--- a/conformance/required/pipeline/pinned-items.toml
+++ b/conformance/required/pipeline/pinned-items.toml
@@ -61,13 +61,13 @@ pinned = true
 content = "old"
 tokens = 150
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "new"
 tokens = 150
 kind = "Message"
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[expected_output]]
 content = "old"

--- a/conformance/required/placing/chronological-basic.toml
+++ b/conformance/required/placing/chronological-basic.toml
@@ -10,19 +10,19 @@ placer = "chronological"
 content = "recent"
 tokens = 100
 score = 0.9
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[items]]
 content = "middle"
 tokens = 100
 score = 0.5
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[items]]
 content = "old"
 tokens = 100
 score = 0.3
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [expected]
 ordered_contents = ["old", "middle", "recent"]

--- a/conformance/required/placing/chronological-null-timestamps.toml
+++ b/conformance/required/placing/chronological-null-timestamps.toml
@@ -15,7 +15,7 @@ score = 0.5
 content = "recent"
 tokens = 100
 score = 0.9
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[items]]
 content = "no-time-b"
@@ -26,7 +26,7 @@ score = 0.3
 content = "old"
 tokens = 100
 score = 0.7
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [expected]
 ordered_contents = ["old", "recent", "no-time-a", "no-time-b"]

--- a/conformance/required/scoring/composite-weighted.toml
+++ b/conformance/required/scoring/composite-weighted.toml
@@ -37,19 +37,19 @@ weight = 1.0
 [[items]]
 content = "old-low"
 tokens = 100
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 priority = 1
 
 [[items]]
 content = "new-high"
 tokens = 100
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 priority = 10
 
 [[items]]
 content = "old-high"
 tokens = 100
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 priority = 10
 
 [[expected]]

--- a/conformance/required/scoring/decay-future-dated.toml
+++ b/conformance/required/scoring/decay-future-dated.toml
@@ -4,13 +4,13 @@ stage = "scoring"
 scorer = "decay"
 
 # referenceTime = 2025-01-01T12:00:00Z
-# item timestamp  = 2025-01-02T00:00:00Z  →  timestamp > now → age clamps to 0
+# item timestamp  = 2025-01-02T00:00Z  →  timestamp > now → age clamps to 0
 # halfLife = 24 h  →  score = 2^(0) = 1.0
 
 [[items]]
 content = "future-item"
 tokens = 100
-timestamp = 2025-01-02T00:00:00Z
+timestamp = 2025-01-02T00:00Z
 
 [[expected]]
 content = "future-item"

--- a/conformance/required/scoring/recency-basic.toml
+++ b/conformance/required/scoring/recency-basic.toml
@@ -12,17 +12,17 @@ scorer = "recency"
 [[items]]
 content = "oldest"
 tokens = 100
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "middle"
 tokens = 100
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[items]]
 content = "newest"
 tokens = 100
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[expected]]
 content = "oldest"

--- a/conformance/required/scoring/recency-null-timestamps.toml
+++ b/conformance/required/scoring/recency-null-timestamps.toml
@@ -12,12 +12,12 @@ scorer = "recency"
 [[items]]
 content = "old"
 tokens = 100
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "new"
 tokens = 100
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[items]]
 content = "no-timestamp-a"

--- a/spec/conformance/required/pipeline/composite-greedy-chronological.toml
+++ b/spec/conformance/required/pipeline/composite-greedy-chronological.toml
@@ -70,25 +70,25 @@ weight = 1.0
 content = "sys-old"
 tokens = 100
 kind = "SystemPrompt"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "msg-mid"
 tokens = 150
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[items]]
 content = "msg-new"
 tokens = 150
 kind = "Message"
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[items]]
 content = "doc-old"
 tokens = 200
 kind = "Document"
-timestamp = 2024-02-01T00:00:00Z
+timestamp = 2024-02-01T00:00Z
 
 [[expected_output]]
 content = "sys-old"

--- a/spec/conformance/required/pipeline/diag-deduplicated.toml
+++ b/spec/conformance/required/pipeline/diag-deduplicated.toml
@@ -57,13 +57,13 @@ weight = 1.0
 content = "dup-content"
 tokens = 50
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "dup-content"
 tokens = 50
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[expected_output]]
 content = "dup-content"

--- a/spec/conformance/required/pipeline/diag-negative-tokens.toml
+++ b/spec/conformance/required/pipeline/diag-negative-tokens.toml
@@ -47,13 +47,13 @@ weight = 1.0
 content = "neg-item"
 tokens = -5
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "normal-item"
 tokens = 100
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[expected_output]]
 content = "normal-item"

--- a/spec/conformance/required/pipeline/diag-pinned-override.toml
+++ b/spec/conformance/required/pipeline/diag-pinned-override.toml
@@ -77,7 +77,7 @@ pinned = true
 content = "regular-item"
 tokens = 80
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[expected_output]]
 content = "pinned-item"

--- a/spec/conformance/required/pipeline/diag-scored-inclusion.toml
+++ b/spec/conformance/required/pipeline/diag-scored-inclusion.toml
@@ -60,13 +60,13 @@ weight = 1.0
 content = "older-item"
 tokens = 50
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "newer-item"
 tokens = 50
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[expected_output]]
 content = "older-item"

--- a/spec/conformance/required/pipeline/diagnostics-budget-exceeded.toml
+++ b/spec/conformance/required/pipeline/diagnostics-budget-exceeded.toml
@@ -43,13 +43,13 @@ weight = 1.0
 content = "fits"
 tokens = 150
 kind = "Message"
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[items]]
 content = "too-big"
 tokens = 400
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[expected_output]]
 content = "fits"

--- a/spec/conformance/required/pipeline/greedy-chronological.toml
+++ b/spec/conformance/required/pipeline/greedy-chronological.toml
@@ -46,25 +46,25 @@ weight = 1.0
 content = "jan"
 tokens = 200
 kind = "Message"
-timestamp = 2024-01-15T00:00:00Z
+timestamp = 2024-01-15T00:00Z
 
 [[items]]
 content = "mar"
 tokens = 200
 kind = "Message"
-timestamp = 2024-03-15T00:00:00Z
+timestamp = 2024-03-15T00:00Z
 
 [[items]]
 content = "aug"
 tokens = 150
 kind = "Message"
-timestamp = 2024-08-15T00:00:00Z
+timestamp = 2024-08-15T00:00Z
 
 [[items]]
 content = "dec"
 tokens = 150
 kind = "Message"
-timestamp = 2024-12-15T00:00:00Z
+timestamp = 2024-12-15T00:00Z
 
 [[expected_output]]
 content = "aug"

--- a/spec/conformance/required/pipeline/greedy-ushaped.toml
+++ b/spec/conformance/required/pipeline/greedy-ushaped.toml
@@ -46,25 +46,25 @@ weight = 1.0
 content = "oldest"
 tokens = 200
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "early"
 tokens = 150
 kind = "Message"
-timestamp = 2024-04-01T00:00:00Z
+timestamp = 2024-04-01T00:00Z
 
 [[items]]
 content = "late"
 tokens = 150
 kind = "Message"
-timestamp = 2024-09-01T00:00:00Z
+timestamp = 2024-09-01T00:00Z
 
 [[items]]
 content = "newest"
 tokens = 100
 kind = "Message"
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[expected_output]]
 content = "newest"

--- a/spec/conformance/required/pipeline/knapsack-chronological.toml
+++ b/spec/conformance/required/pipeline/knapsack-chronological.toml
@@ -59,21 +59,21 @@ content = "alpha"
 tokens = 200
 kind = "Message"
 priority = 2
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "beta"
 tokens = 150
 kind = "Message"
 priority = 5
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[items]]
 content = "gamma"
 tokens = 250
 kind = "Message"
 priority = 8
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[expected_output]]
 content = "gamma"

--- a/spec/conformance/required/pipeline/pinned-items.toml
+++ b/spec/conformance/required/pipeline/pinned-items.toml
@@ -61,13 +61,13 @@ pinned = true
 content = "old"
 tokens = 150
 kind = "Message"
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "new"
 tokens = 150
 kind = "Message"
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[expected_output]]
 content = "old"

--- a/spec/conformance/required/placing/chronological-basic.toml
+++ b/spec/conformance/required/placing/chronological-basic.toml
@@ -10,19 +10,19 @@ placer = "chronological"
 content = "recent"
 tokens = 100
 score = 0.9
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[items]]
 content = "middle"
 tokens = 100
 score = 0.5
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[items]]
 content = "old"
 tokens = 100
 score = 0.3
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [expected]
 ordered_contents = ["old", "middle", "recent"]

--- a/spec/conformance/required/placing/chronological-null-timestamps.toml
+++ b/spec/conformance/required/placing/chronological-null-timestamps.toml
@@ -15,7 +15,7 @@ score = 0.5
 content = "recent"
 tokens = 100
 score = 0.9
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[items]]
 content = "no-time-b"
@@ -26,7 +26,7 @@ score = 0.3
 content = "old"
 tokens = 100
 score = 0.7
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [expected]
 ordered_contents = ["old", "recent", "no-time-a", "no-time-b"]

--- a/spec/conformance/required/scoring/composite-weighted.toml
+++ b/spec/conformance/required/scoring/composite-weighted.toml
@@ -37,19 +37,19 @@ weight = 1.0
 [[items]]
 content = "old-low"
 tokens = 100
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 priority = 1
 
 [[items]]
 content = "new-high"
 tokens = 100
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 priority = 10
 
 [[items]]
 content = "old-high"
 tokens = 100
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 priority = 10
 
 [[expected]]

--- a/spec/conformance/required/scoring/decay-future-dated.toml
+++ b/spec/conformance/required/scoring/decay-future-dated.toml
@@ -4,13 +4,13 @@ stage = "scoring"
 scorer = "decay"
 
 # referenceTime = 2025-01-01T12:00:00Z
-# item timestamp  = 2025-01-02T00:00:00Z  →  timestamp > now → age clamps to 0
+# item timestamp  = 2025-01-02T00:00Z  →  timestamp > now → age clamps to 0
 # halfLife = 24 h  →  score = 2^(0) = 1.0
 
 [[items]]
 content = "future-item"
 tokens = 100
-timestamp = 2025-01-02T00:00:00Z
+timestamp = 2025-01-02T00:00Z
 
 [[expected]]
 content = "future-item"

--- a/spec/conformance/required/scoring/recency-basic.toml
+++ b/spec/conformance/required/scoring/recency-basic.toml
@@ -12,17 +12,17 @@ scorer = "recency"
 [[items]]
 content = "oldest"
 tokens = 100
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "middle"
 tokens = 100
-timestamp = 2024-06-01T00:00:00Z
+timestamp = 2024-06-01T00:00Z
 
 [[items]]
 content = "newest"
 tokens = 100
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[expected]]
 content = "oldest"

--- a/spec/conformance/required/scoring/recency-null-timestamps.toml
+++ b/spec/conformance/required/scoring/recency-null-timestamps.toml
@@ -12,12 +12,12 @@ scorer = "recency"
 [[items]]
 content = "old"
 tokens = 100
-timestamp = 2024-01-01T00:00:00Z
+timestamp = 2024-01-01T00:00Z
 
 [[items]]
 content = "new"
 tokens = 100
-timestamp = 2024-12-01T00:00:00Z
+timestamp = 2024-12-01T00:00Z
 
 [[items]]
 content = "no-timestamp-a"


### PR DESCRIPTION
## S02: Adopt TOML 1.1 Syntax in Vectors & Document Requirement

**Milestone:** M001 — Bump toml to 1.1 & Adopt TOML 1.1 Conformance

### What this PR does

Applies TOML 1.1 optional-seconds datetime simplification to all conformance vector files, documents the TOML 1.1 parser requirement in `conformance/README.md`, and syncs the spec mirror. Pure data change — no Rust code modifications.

**Changes:**
- `T00:00:00Z` → `T00:00Z` in 21 vector files (16 required + 5 optional) — 41 timestamp occurrences
- `conformance/README.md` — new "TOML Version" section documenting TOML 1.1 as the minimum parser requirement
- `spec/conformance/required/` — synced byte-identical with `conformance/required/` (16 files)

**Deliberately skipped (per research):**
- Trailing commas in inline tables — all 6 inline tables are single-entry; no readability gain
- Multi-line inline tables — array-of-tables syntax already clear
- `\xHH`/`\e` escapes — no escape sequences present in any vector

### Verification

| Check | Result |
| -- | -- |
| `grep -r 'T00:00:00Z' conformance/ --include='*.toml'` — no matches | ✅ |
| `grep -rl 'T00:00Z' conformance/required/` — 16 files | ✅ |
| `grep -i 'TOML 1.1' conformance/README.md` — found | ✅ |
| `diff -rq conformance/required/ spec/conformance/required/` — no diff | ✅ |
| `cargo test` — 266 passed, 2 ignored, 0 failed | ✅ |
| `cargo clippy` — no issues | ✅ |

### Requirements

| ID | Requirement | Status |
| -- | -- | -- |
| R003 | Adopt TOML 1.1 syntax in test vectors | ✅ validated |
| R004 | Document TOML 1.1 requirement for consumers | ✅ validated |
| R002 | All tests pass (supporting) | ✅ validated |

This completes M001 — all 4 requirements (R001–R004) are now validated.